### PR TITLE
Rebuild website with portfolio placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Marchant Web '24
+# Portfolio Starter (Marchant-Web base)
 
 ![Homepage Screenshot](public/cover.jpg)
 
-This repo contains the latest code for [MarchantWeb.com](https://marchantweb.com). It's a Nuxt 3 project that centers around a WebGL visualization that ebs and flows into each page.
+This is a Nuxt 3 portfolio starter derived from Marchant-Web, with content replaced by placeholders. It centers around a WebGL visualization with GSAP animations and AOS scroll effects.
 
 I've made the code open-source, with the obvious caveat that it's meant to act as a reference for learning and developing your own creative website, and that you cannot clone it and pretend to be me.
 
-For the sake of security, the connection to Notion's API is abstracted behind a service at `api.marchantweb.com`, which is not open-source. You won't find any secret keys here.
+All data is local under `public/data` and no external API keys are required.
 
 ### Technology 🚀
 

--- a/app.vue
+++ b/app.vue
@@ -21,7 +21,7 @@
 import {useHead} from "nuxt/app";
 
 useHead({
-  title: 'Home — Simon Le Marchant',
+  title: 'Home — Your Name',
   viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
   lang: 'en-US',
   charset: 'utf-8',
@@ -32,7 +32,7 @@ useHead({
     {
       hid: 'description',
       name: 'description',
-      content: 'Hey I\'m Simon — a front-end engineer with 15+ years in leading and crafting innovative web projects.'
+      content: 'Independent designer/developer portfolio — projects, updates, services, contact.'
     },
     {
       hid: 'theme-color',
@@ -52,12 +52,12 @@ useHead({
     {
       hid: 'og:url',
       name: 'og:url',
-      content: 'https://marchantweb.com'
+      content: 'https://your-portfolio.example.com'
     },
     {
       hid: 'og:title',
       name: 'og:title',
-      content: 'Simon Le Marchant | Independent Interactive Developer'
+      content: 'Your Name | Portfolio'
     },
     {
       hid: 'og:type',
@@ -67,22 +67,22 @@ useHead({
     {
       hid: 'og:image',
       name: 'og:image',
-      content: 'https://marchantweb.com/cover.jpg'
+      content: 'https://via.placeholder.com/1200x630.png?text=Portfolio+Cover'
     },
     {
       hid: 'og:image:alt',
       name: 'og:image:alt',
-      content: 'Simon Le Marchant | Independent Interactive Developer'
+      content: 'Your Name | Portfolio'
     },
     {
       hid: 'og:description',
       name: 'og:description',
-      content: 'Hey I\'m Simon — a front-end engineer with 15+ years in leading and crafting innovative web projects.'
+      content: 'Independent designer/developer portfolio — projects, updates, services, contact.'
     },
     {
       hid: 'og:site_name',
       name: 'og:site_name',
-      content: 'Simon Le Marchant | Independent Interactive Developer'
+      content: 'Your Name | Portfolio'
     },
     {
       hid: 'og:locale',
@@ -97,42 +97,42 @@ useHead({
     {
       hid: 'twitter:site',
       name: 'twitter:site',
-      content: '@marchantweb'
+      content: '@yourhandle'
     },
     {
       hid: 'twitter:creator',
       name: 'twitter:creator',
-      content: '@marchantweb'
+      content: '@yourhandle'
     },
     {
       hid: 'twitter:url',
       name: 'twitter:url',
-      content: 'https://marchantweb.com'
+      content: 'https://your-portfolio.example.com'
     },
     {
       hid: 'twitter:title',
       name: 'twitter:title',
-      content: 'Simon Le Marchant | Independent Interactive Developer'
+      content: 'Your Name | Portfolio'
     },
     {
       hid: 'twitter:description',
       name: 'twitter:description',
-      content: 'Hey I’m Simon, an independent interactive developer based in Orlando, Florida.'
+      content: 'Independent designer/developer portfolio — projects, updates, services, contact.'
     },
     {
       hid: 'twitter:image',
       name: 'twitter:image',
-      content: 'https://marchantweb.com/cover.jpg'
+      content: 'https://via.placeholder.com/1200x630.png?text=Portfolio+Cover'
     },
     {
       hid: 'twitter:image:alt',
       name: 'twitter:image:alt',
-      content: 'Simon Le Marchant | Independent Interactive Developer'
+      content: 'Your Name | Portfolio'
     }
   ],
   link: [
     {rel: 'icon', type: 'image/svg', href: '/icon-notext.svg'},
-    {rel: 'preconnect', href: 'https://api.marchantweb.com'},
+    {rel: 'preconnect', href: 'https://example.com'},
     {
       rel: 'stylesheet',
       href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap'

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,4 +1,4 @@
-/* Marchant Web */
+/* Portfolio Placeholder Theme */
 
 html {
   font-size: 15px;

--- a/components/BottomBar.vue
+++ b/components/BottomBar.vue
@@ -2,19 +2,19 @@
   <div class="bottom-bar row pb-2 pb-md-3 align-items-end d-flex justify-content-between">
     <div class="col-auto d-flex align-items-center" itemscope itemtype="https://schema.org/Person">
       <MWIcon :size="45" class="pb-2" type="notext"/>
-      <h1 class="bottom-navigation__title ms-4"><span itemprop="name">Simon Le Marchant</span><br><span
-          itemprop="jobTitle">Independent Interactive Developer</span></h1>
+      <h1 class="bottom-navigation__title ms-4"><span itemprop="name">Your Name</span><br><span
+          itemprop="jobTitle">Designer / Developer</span></h1>
     </div>
     <div class="col-auto mb-3 d-flex align-items-center">
-      <a href="https://twitter.com/marchantweb" target="_blank" class="me-4 text-decoration-none"
+      <a href="#" target="_blank" class="me-4 text-decoration-none"
                 aria-label="Find me on Twitter"><i
           class="fa-brands fa-x-twitter fa-xl twitter-icon mouse-sm d-none d-xl-inline text-decoration-none"
           title="Find me on Twitter"></i></a>
-      <a href="https://github.com/marchantweb/Marchant-Web" target="_blank" class="me-4 text-decoration-none"
+      <a href="#" target="_blank" class="me-4 text-decoration-none"
                 aria-label="View this site on GitHub"><i
           class="fa-brands fa-github fa-xl github-icon mouse-sm d-none d-xl-inline text-decoration-none"
           title="View this site on GitHub"></i></a>
-      <a href="https://www.linkedin.com/in/marchantweb/" target="_blank" class="me-5 text-decoration-none"
+      <a href="#" target="_blank" class="me-5 text-decoration-none"
                 aria-label="Find me on LinkedIn"><i
           class="fa-brands fa-linkedin fa-xl linkedin-icon mouse-sm d-none d-xl-inline text-decoration-none"
           title="Find me on LinkedIn"></i></a>

--- a/components/notion/Image.vue
+++ b/components/notion/Image.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="col-12 my-4 my-lg-5">
     <figure data-aos="fade-up">
-    <img v-once v-if="'file' in block['image']" class="my-4 mouse-sm" :src="'https://marchantweb.com/cdn-cgi/image/width=1974,quality=100,format=auto/https://api.marchantweb.com/images/' + encodeURI(block['id'])" alt="Creative programming.">
-      <img v-once v-if="'external' in block['image']" class="my-4 mouse-sm" :src="block['image']['external']['url']" alt="Creative programming.">
+      <img v-once v-if="'file' in block['image']" class="my-4 mouse-sm" :src="block['image']['file']?.url || ''" alt="Image.">
+      <img v-once v-if="'external' in block['image']" class="my-4 mouse-sm" :src="block['image']['external']['url']" alt="Image.">
       <figcaption v-if="'caption' in block['image'] && block['image']['caption'].length > 0"><i class="fa-sharp fa-regular fa-circle-info pe-2" aria-hidden></i> {{block['image']['caption'][0]['plain_text']}}</figcaption>
     </figure>
   </div>

--- a/composables/useArticles.js
+++ b/composables/useArticles.js
@@ -1,7 +1,7 @@
 export const useArticles = async (listedOnly = false) => {
     const articles = useState('articles', () => []);
     if (articles.value.length === 0) {
-        articles.value = await $fetch('https://api.marchantweb.com/articles');
+        articles.value = await $fetch('/data/articles.json');
     }
     if(listedOnly){
         return ref(articles.value.filter(item => item["listed"]));

--- a/composables/useMetadata.js
+++ b/composables/useMetadata.js
@@ -1,7 +1,7 @@
 export const useMetadata = async () => {
     const metadata = useState('metadata', () => null);
     if (!metadata.value) {
-        metadata.value = await $fetch('https://api.marchantweb.com/metadata');
+        metadata.value = await $fetch('/data/metadata.json');
     }
     return metadata;
 }

--- a/composables/usePortfolio.js
+++ b/composables/usePortfolio.js
@@ -2,16 +2,15 @@ export const usePortfolio = async (listedOnly = false) => {
     const portfolio = useState('portfolio', () => []);
     if (portfolio.value.length === 0) {
         if (portfolio.value.length === 0) {
-            let fetchedPortfolio = await $fetch('https://api.marchantweb.com/portfolio');
+            let fetchedPortfolio = await $fetch('/data/portfolio.json');
             fetchedPortfolio = fetchedPortfolio.map(item => {
                 let featuredImage = item['cover'];
-                for (let block of item['pageContent']) {
+                for (let block of item['pageContent'] || []) {
                     if (block.type === 'image') {
-                        featuredImage = 'https://marchantweb.com/cdn-cgi/image/width=1974,quality=100,format=auto/https://api.marchantweb.com/images/' + encodeURI(block['id']);
+                        featuredImage = block.image?.url || featuredImage;
                         break;
                     }
                 }
-                console.log(featuredImage);
                 return {...item, 'featuredImage': featuredImage};
             });
             portfolio.value = fetchedPortfolio;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,16 +1,12 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
     site: {
-        name: 'Marchant Web',
-        url: 'https://marchantweb.com',
-        description: 'Hey I\'m Simon — a front-end engineer with 15+ years in leading and crafting innovative web projects.',
+        name: 'Your Name Portfolio',
+        url: 'https://your-portfolio.example.com',
+        description: 'Independent designer/developer portfolio — projects, updates, services, contact.',
         defaultLocale: 'en',
     },
-    sitemap: {
-        sources: [
-            'https://api.marchantweb.com/sitemap',
-        ]
-    },
+    sitemap: {},
     app: {
         pageTransition: {name: 'page', mode: 'out-in'},
         head: {
@@ -27,7 +23,7 @@ export default defineNuxtConfig({
         }
     },
     gtag: {
-        id: 'G-E1LXB89D1E'
+        id: 'G-XXXXXXX'
     },
     devtools: {
         enabled: true,

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -11,9 +11,9 @@
             <span class="code--green">&nbsp;not</span>
             <span class="code--white">&nbsp;found</span>
           </CodeLine>
-          <h1 class="mb-5 lead">OH SH***T;</h1>
+          <h1 class="mb-5 lead">Page Not Found</h1>
           <p class="text-light mb-6">
-            Looks you've navigated to a broken link.<br><em>Try not doing that again in the future.</em>
+            Looks like you've navigated to a broken link.<br><em>Please use the menu to continue.</em>
           </p>
           <ActionButton to="/" data-aos="fade-up">
             <i class="fa-sharp fa-solid fa-arrow-up-left"></i>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -9,30 +9,23 @@
                 class="fa-sharp fa-solid fa-arrow-up-right fa-2x ps-3"></i></NuxtLink>
             <CodeTag class="mt-5 mb-5 d-none d-lg-block">about</CodeTag>
             <div class="d-flex flex-row align-items-center mb-5">
-              <img src="~assets/images/headshot.jpg" alt="Hey I'm Simon" class="headshot me-4 me-lg-5">
+              <img src="~assets/images/headshot.jpg" alt="Headshot" class="headshot me-4 me-lg-5">
             </div>
-            <h2 class="my-4" itemprop="description">Hey I'm Simon — an independent interactive developer with 15+ years of
-              crafting innovative web projects.</h2>
+            <h2 class="my-4" itemprop="description">Hey I'm Your Name — an independent designer/developer crafting modern web experiences.</h2>
             <div itemprop="knowsAbout">
               <p>
                 I build things with <a
-                  href="https://vuejs.org/" target="_blank" class="mouse-sm">Vue</a> and it's ecosystem of tooling.
-                Before specializing in the frontend, I was a full-stack developer putting together enterprise-scale
-                websites. I enjoy challenging Chrome and Safari to a battle of wits <em>(or patience)</em> and
-                architecting simple solutions to complex problems.
+                  href="https://vuejs.org/" target="_blank" class="mouse-sm">Vue</a>, modern CSS, and WebGL.
+                I enjoy designing delightful interactions and architecting simple solutions to complex problems.
               </p>
               <p>
-                I've worked with a wide range of teams, from startups to Fortune 500 companies; typically in a principal
-                technical role. Usually I partner with agencies, design studios, or startups to provide sprints of
-                focused dev work.
+                I collaborate with startups, agencies, and design studios to deliver sprints of focused product and web work.
               </p>
               <p>
-                On a personal note... I live in Orlando FL with my wife and daughter. I <em
-                  style="text-decoration: underline">want</em> to say that I'm a big fan of the outdoors and that I like
-                long walks on the beach; but instead my passion is programming so I'm usually just at my desk 🧑‍💻
+                On a personal note... I love tinkering, learning, and building. When I'm not coding, I'm sketching ideas.
               </p>
             </div>
-            <h3 class="mt-5 mb-3">Some teams I've worked with:</h3>
+            <h3 class="mt-5 mb-3">Some teams I've collaborated with:</h3>
           </div>
           <div class="col-12 col-md-8 col-lg-7 col-xl-6 col-xxxl-6">
             <div class="client-logo__container">
@@ -54,14 +47,12 @@
           <div class="col-12 col-md-8 col-lg-7 col-xl-6 col-xxl-5 mb-4 mb-lg-8">
             <h3 class="mt-5 mb-4">Availability</h3>
             <p>
-              I'm interested in collaborating with people who are building creative websites, interactive experiences,
-              or bespoke interfaces — especially those with graphics so intense that my GPU catches fire 🔥
+              I'm interested in collaborating on creative websites, interactive experiences, and bespoke interfaces.
             </p>
             <p class="mb-5">
-              While I always have some sort of ongoing work, I'm open to discussing new opportunities. If you
-              have a project in mind, don't hesitate to reach out.
+              If you have a project in mind, feel free to reach out.
             </p>
-            <ActionButton to="https://calendly.com/marchantweb/discovery" target="_blank" class="mb-6">
+            <ActionButton to="#contact" target="_blank" class="mb-6">
               <i class="fa-sharp fa-light fa-paper-plane"></i>
               Let's chat
             </ActionButton>
@@ -77,11 +68,11 @@
 <script setup>
 
 useHead({
-  title: 'Hey I\'m Simon — a front-end engineer with 15+ years in leading and crafting innovative web projects. | Marchant Web',
+  title: 'About — Your Name | Portfolio',
   meta: [
     {
       name: 'description',
-      content: 'Hey I\'m Simon — a front-end engineer with 15+ years in leading and crafting innovative web projects.'
+      content: 'Independent designer/developer crafting modern web experiences.'
     }
   ],
   bodyAttrs: {

--- a/pages/article/[...slug].vue
+++ b/pages/article/[...slug].vue
@@ -17,10 +17,10 @@
             <h1 class="mb-3 mb-lg-4 article__title mouse-md"> {{ currentArticleItem['title'] }} </h1>
             <h2 class="article__lead mb-5"> {{ currentArticleItem['lead'] }} </h2>
             <div class="d-flex flex-row align-items-center mb-4">
-              <img src="~assets/images/headshot.jpg" alt="Simon Le Marchant" class="article__headshot me-4 mouse-sm">
+              <img src="~assets/images/headshot.jpg" alt="Your Name" class="article__headshot me-4 mouse-sm">
               <div>
-                <label class="article__author" itemprop="name">Simon Le Marchant · <a
-                    href="https://twitter.com/marchantweb" target="blank" class="article__followlink mouse-sm">Follow on
+                <label class="article__author" itemprop="name">Your Name · <a
+                    href="#" target="blank" class="article__followlink mouse-sm">Follow on
                   𝕏</a></label>
                 <span class="article__readtime">{{ readTime }} · {{ formattedDate }} </span>
               </div>
@@ -29,7 +29,7 @@
           </div>
           <NotionContent class="article__content" :isArticle="true" :blocks="currentArticleItem['pageContent']"/>
           <p class="mt-7 mt-xxl-8 mt-xxxl-9 text-small text-end copyright d-none d-lg-block">Copyright ©
-            {{ new Date().getFullYear() }} Marchant Web, LLC. All rights reserved.</p>
+            {{ new Date().getFullYear() }} Your Name. All rights reserved.</p>
         </main>
       </div>
 
@@ -72,10 +72,14 @@ const readTime = computed(() => {
  * @type {ComputedRef<string>}
  */
 const coverImage = computed(() => {
-  let coverImage = 'https://marchantweb.com/cover.jpg';
+  let coverImage = '/cover.jpg';
   for (let block of currentArticleItem.value['pageContent']) {
     if (block.type === 'image') {
-      coverImage = 'https://marchantweb.com/cdn-cgi/image/width=1974,quality=100,format=auto/https://api.marchantweb.com/images/' + encodeURI(block['id']);
+      if (block.image?.file?.url) {
+        coverImage = block.image.file.url;
+      } else if (block.image?.external?.url) {
+        coverImage = block.image.external.url;
+      }
       break;
     }
   }
@@ -107,18 +111,18 @@ useHead({
   meta: [
     {hid: 'description', name: 'description', content: currentArticleItem.value['lead']},
     {hid: 'og:title', property: 'og:title', content: currentArticleItem.value['title']},
-    {hid: 'og:url', property: 'og:url', content: 'https://marchantweb.com' + route.fullPath},
+    {hid: 'og:url', property: 'og:url', content: 'https://your-portfolio.example.com' + route.fullPath},
     {hid: 'og:description', property: 'og:description', content: currentArticleItem.value['lead']},
     {hid: 'og:image', property: 'og:image', content: coverImage.value},
 
     // twitter card
     {hid: "twitter:title", name: "twitter:title", content: currentArticleItem.value['title']},
-    {hid: "twitter:url", name: "twitter:url", content: 'https://marchantweb.com' + route.fullPath},
+    {hid: "twitter:url", name: "twitter:url", content: 'https://your-portfolio.example.com' + route.fullPath},
     {hid: 'twitter:description', name: 'twitter:description', content: currentArticleItem.value['lead']},
     {hid: "twitter:image", name: "twitter:image", content: coverImage.value},
   ],
   link: [
-    {hid: "canonical", rel: "canonical", href: 'https://marchantweb.com' + route.fullPath},
+    {hid: "canonical", rel: "canonical", href: 'https://your-portfolio.example.com' + route.fullPath},
   ],
   bodyAttrs: {
     class: 'enable-scroll'
@@ -132,8 +136,8 @@ useSchemaOrg([
     'description': currentArticleItem.value['lead'],
     'image': coverImage.value,
     'author': {
-      'name': 'Simon Le Marchant',
-      'url': 'https://marchantweb.com'
+      'name': 'Your Name',
+      'url': 'https://your-portfolio.example.com'
     },
   }
 ])

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -8,14 +8,14 @@
           </NuxtLink>
           <CodeTag class="mt-5 mb-3">contact</CodeTag>
           <h1 class="mb-4">Let's Chat</h1>
-          <p class="mb-4">In 2024 — alongside my ongoing projects I'm keen to explore additional opportunities that spark creativity and challenge. If you have a project in mind, feel free to schedule a time to chat.</p>
-          <ActionButton to="https://calendly.com/marchantweb/discovery" target="_blank" class="mb-6">
+          <p class="mb-4">I'm open to new projects that spark creativity and challenge. If you have something in mind, schedule a time to connect.</p>
+          <ActionButton to="#contact" target="_blank" class="mb-6">
             <i class="fa-sharp fa-light fa-paper-plane"></i>
             Let's chat
           </ActionButton>
           <hr class="mb-6">
           <h3 class="mb-3">Alternate contact options</h3>
-          <p class="mb-4">You can find me posting occasionally on <a href="https://twitter.com/marchantweb" target="blank" class="article__followlink mouse-sm">Twitter / 𝕏 (@marchantweb)</a> or email me at <a href="mailto:hello@marchantweb.com" target="blank" class="mouse-md" style="color: #7A4FEE">hello@marchantweb.com</a>.</p>
+          <p class="mb-4">Find me on <a href="#" target="blank" class="article__followlink mouse-sm">Twitter / 𝕏 (@yourhandle)</a> or email <a href="mailto:hello@example.com" target="blank" class="mouse-md" style="color: #7A4FEE">hello@example.com</a>.</p>
         </div>
         <div class="col-1 d-none d-xl-block"></div>
       </div>
@@ -27,11 +27,11 @@
 <script setup>
 
 useHead({
-  title: 'Let\'s Chat - Schedule a Discovery Session | Marchant Web',
+  title: 'Let\'s Chat - Get in Touch | Your Name',
   meta: [
     {
       name: 'description',
-      content: 'Schedule a one-hour initial discovery session for your project, or reach out via email.'
+      content: 'Reach out to discuss projects, services, or collaborations.'
     }
   ],
   bodyAttrs: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <section class="page">
 
     <div id="awwwards" class="d-none d-lg-block"><a
-        href="https://www.awwwards.com/sites/marchant-web" target="_blank" class="mouse-md">
+        href="#" target="_blank" class="mouse-md">
       <svg width="53.08" height="171.358">
         <path class="js-color-bg" fill="white" d="M0 0h53.08v171.358H0z"></path>
         <g class="js-color-text" fill="black">

--- a/pages/portfolio/[...slug].vue
+++ b/pages/portfolio/[...slug].vue
@@ -46,7 +46,7 @@
               <dd v-if="currentPortfolioItem['awards']" v-html="currentPortfolioItem['awards'].replace(/\n/g, '<br />')"></dd>
 
             </dl>
-            <ActionButton to="https://calendly.com/marchantweb/discovery" target="_blank" class="mb-6">
+            <ActionButton to="#contact" target="_blank" class="mb-6">
               <i class="fa-sharp fa-light fa-paper-plane"></i>
               Let's chat
             </ActionButton>
@@ -62,7 +62,7 @@
             <h1 class="mb-4 mb-lg-5" data-aos="fade-up">{{ currentPortfolioItem['lead'] }}</h1>
           </div>
           <NotionContent :blocks="currentPortfolioItem['pageContent']"/>
-          <p class="mt-7 mt-xxl-8 mt-xxxl-9 text-small text-end copyright d-none d-lg-block">Copyright © {{new Date().getFullYear()}} Marchant Web, LLC. All rights reserved.</p>
+          <p class="mt-7 mt-xxl-8 mt-xxxl-9 text-small text-end copyright d-none d-lg-block">Copyright © {{new Date().getFullYear()}} Your Name. All rights reserved.</p>
         </main>
       </div>
 
@@ -81,22 +81,22 @@ const currentPortfolioItem = computed(() => {
 });
 
 useHead({
-  title: 'Case Study: ' + currentPortfolioItem.value['title'] + ', ' + currentPortfolioItem.value['type'] + ' | ' + 'Marchant Web',
+  title: 'Case Study: ' + currentPortfolioItem.value['title'] + ', ' + currentPortfolioItem.value['type'] + ' | Your Name',
   meta: [
     { hid: 'description', name: 'description', content:  currentPortfolioItem.value['lead'] },
     { hid: 'og:title', property: 'og:title', content: currentPortfolioItem.value['title'] },
-    { hid: 'og:url', property: 'og:url', content: 'https://marchantweb.com' + route.fullPath },
+    { hid: 'og:url', property: 'og:url', content: 'https://your-portfolio.example.com' + route.fullPath },
     { hid: 'og:description', property: 'og:description', content: currentPortfolioItem.value['lead'] },
     { hid: 'og:image', property: 'og:image', content: currentPortfolioItem.value['cover']},
 
     // twitter card
     { hid: "twitter:title", name: "twitter:title", content: currentPortfolioItem.value['title'] },
-    { hid: "twitter:url", name: "twitter:url", content: 'https://marchantweb.com' + route.fullPath },
+    { hid: "twitter:url", name: "twitter:url", content: 'https://your-portfolio.example.com' + route.fullPath },
     { hid: 'twitter:description', name: 'twitter:description', content: currentPortfolioItem.value['lead'] },
     { hid: "twitter:image", name: "twitter:image", content: currentPortfolioItem.value['cover']},
   ],
   link: [
-    { hid: "canonical", rel: "canonical", href: 'https://marchantweb.com' + route.fullPath },
+    { hid: "canonical", rel: "canonical", href: 'https://your-portfolio.example.com' + route.fullPath },
   ],
   bodyAttrs: {
     class: 'enable-scroll'

--- a/public/data/articles.json
+++ b/public/data/articles.json
@@ -1,0 +1,32 @@
+[
+  {
+    "slug": "update-welcome",
+    "title": "Welcome to my portfolio",
+    "lead": "A short note about this placeholder portfolio.",
+    "listed": true,
+    "createdAt": "2024-06-01T00:00:00.000Z",
+    "pageContent": [
+      {
+        "id": "a1",
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [
+            {
+              "plain_text": "This site showcases projects and experiments.",
+              "text": {"content": "This site showcases projects and experiments."},
+              "annotations": {"bold": false, "italic": false, "underline": false, "code": false, "color": ""}
+            }
+          ]
+        }
+      },
+      {
+        "id": "a2",
+        "type": "image",
+        "image": {
+          "external": {"url": "https://via.placeholder.com/1200x630.png?text=Article+Image"},
+          "caption": []
+        }
+      }
+    ]
+  }
+]

--- a/public/data/metadata.json
+++ b/public/data/metadata.json
@@ -1,0 +1,3 @@
+{
+  "status": "Available for new projects"
+}

--- a/public/data/portfolio.json
+++ b/public/data/portfolio.json
@@ -1,0 +1,77 @@
+[
+  {
+    "slug": "project-one",
+    "title": "Project One",
+    "type": "Web Experience",
+    "listed": true,
+    "lead": "A short summary of the project highlighting goals and outcomes.",
+    "client": "Client Name",
+    "partner": "Studio / Agency",
+    "role": "Design, Development",
+    "completed": "2024",
+    "awards": "",
+    "cover": "/cover.jpg",
+    "videoWebm": "",
+    "videoMP4": "",
+    "featuredImage": "/cover.jpg",
+    "pageContent": [
+      {
+        "id": "b1",
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [
+            {
+              "plain_text": "This is a placeholder case study paragraph.",
+              "text": {"content": "This is a placeholder case study paragraph."},
+              "annotations": {"bold": false, "italic": false, "underline": false, "code": false, "color": ""}
+            }
+          ]
+        }
+      },
+      {
+        "id": "b2",
+        "type": "image",
+        "image": {
+          "file": {"url": "/cover.jpg"},
+          "caption": []
+        }
+      }
+    ]
+  },
+  {
+    "slug": "project-two",
+    "title": "Project Two",
+    "type": "Installations",
+    "listed": true,
+    "lead": "Another placeholder summary for a second project.",
+    "client": "Client Name",
+    "partner": "—",
+    "role": "Development",
+    "completed": "2023",
+    "awards": "",
+    "cover": "/cover.jpg",
+    "videoWebm": "",
+    "videoMP4": "",
+    "featuredImage": "/cover.jpg",
+    "pageContent": [
+      {
+        "id": "b3",
+        "type": "heading_2",
+        "heading_2": {"rich_text": [{"plain_text": "Overview", "text": {"content": "Overview"}, "annotations": {"bold": true, "italic": false, "underline": false, "code": false, "color": ""}}]}
+      },
+      {
+        "id": "b4",
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [
+            {
+              "plain_text": "More placeholder details for this project.",
+              "text": {"content": "More placeholder details for this project."},
+              "annotations": {"bold": false, "italic": false, "underline": false, "code": false, "color": ""}
+            }
+          ]
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Convert the Marchant-Web site into a portfolio starter by replacing all content with placeholders and switching to local data, while preserving its design, animations, and modular structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-33d36040-57c8-4b2d-8540-ae2c6e7094ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33d36040-57c8-4b2d-8540-ae2c6e7094ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

